### PR TITLE
Changed the prediction model for UTR3 in FunUV_predict.py

### DIFF
--- a/FunUV_predict.py
+++ b/FunUV_predict.py
@@ -26,7 +26,7 @@ def main(pfile, region, outp):
     if '5' in region:
         pklfile = pwdir+'/model/GDBoost_for_5UTR.pickle'
     elif '3' in region:
-        pklfile = pwdir+'/model/GDBoost_for_3UTR.pickle'
+        pklfile = pwdir+'/model/GBDT_for_3UTR.pickle'
     model = pickle.load(file=open(pklfile, 'rb'))
     print(model)
     print("Model is ready!")


### PR DESCRIPTION
In script FunUV_predict.py, the prediction model for UTR3 was found to be incorrect. Consequently, it has been revised from 'GDBoost_for_3UTR.pickle' to 'GBDT_for_3UTR.pickle'